### PR TITLE
Feat lucassoliveira gestor pode alocar disciplina e professor no semestre

### DIFF
--- a/src/main/java/com/web/desenvolvimento/edusphere/controllers/AllocationController.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/controllers/AllocationController.java
@@ -1,0 +1,33 @@
+package com.web.desenvolvimento.edusphere.controllers;
+
+import com.web.desenvolvimento.edusphere.dto.allocation.AllocationRequestDTO;
+import com.web.desenvolvimento.edusphere.dto.allocation.AllocationResponseDTO;
+import com.web.desenvolvimento.edusphere.services.allocation.AllocationService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/edusphere/allocations")
+public class AllocationController {
+    private final AllocationService allocationService;
+
+    @Autowired
+    public AllocationController(AllocationService allocationService) {
+        this.allocationService = allocationService;
+    }
+
+    @PostMapping("/register")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<AllocationResponseDTO> create(
+            @RequestBody @Valid AllocationRequestDTO allocationRequestDTO
+    ) {
+        System.out.println(allocationRequestDTO.yearAllocation());
+        return allocationService.create(allocationRequestDTO);
+    }
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/domain/allocation/Allocation.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/domain/allocation/Allocation.java
@@ -14,11 +14,16 @@ import lombok.NoArgsConstructor;
 public class Allocation {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_allocation")
     private Long idAllocation;
 
     @ManyToOne
-    @JoinColumn(name = "idSubjectTaught", nullable = false)
+    @JoinColumn(name = "id_subject_taught", nullable = false)
     private SubjectTaught subjectTaught;
 
+    @Column(name = "semester")
     private String semester;
+
+    @Column(name = "year_allocation")
+    private Long yearAllocation;
 }

--- a/src/main/java/com/web/desenvolvimento/edusphere/domain/allocation/exceptions/SubjectTaughtNotFoundException.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/domain/allocation/exceptions/SubjectTaughtNotFoundException.java
@@ -1,0 +1,7 @@
+package com.web.desenvolvimento.edusphere.domain.allocation.exceptions;
+
+public class SubjectTaughtNotFoundException extends RuntimeException {
+    public SubjectTaughtNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/dto/allocation/AllocationRequestDTO.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/dto/allocation/AllocationRequestDTO.java
@@ -1,0 +1,12 @@
+package com.web.desenvolvimento.edusphere.dto.allocation;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AllocationRequestDTO(
+        Long idAllocation,
+        @NotNull Long idSubjectTaught,
+        @NotBlank String semester,
+        @NotNull Long yearAllocation
+) {
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/dto/allocation/AllocationResponseDTO.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/dto/allocation/AllocationResponseDTO.java
@@ -1,0 +1,13 @@
+package com.web.desenvolvimento.edusphere.dto.allocation;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AllocationResponseDTO(
+        Long idAllocation,
+        @NotBlank String teacherName,
+        @NotBlank String subjectName,
+        @NotBlank String semester,
+        @NotNull Long yearAllocation
+) {
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/mappers/IAllocationMapper.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/mappers/IAllocationMapper.java
@@ -1,0 +1,20 @@
+package com.web.desenvolvimento.edusphere.mappers;
+
+import com.web.desenvolvimento.edusphere.domain.allocation.Allocation;
+import com.web.desenvolvimento.edusphere.dto.allocation.AllocationRequestDTO;
+import com.web.desenvolvimento.edusphere.dto.allocation.AllocationResponseDTO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface IAllocationMapper {
+    IAllocationMapper INSTANCE = Mappers.getMapper(IAllocationMapper.class);
+
+    @Mapping(source = "yearAllocation", target = "yearAllocation")
+    Allocation toModel(AllocationRequestDTO allocationRequestDTO);
+
+    @Mapping(source = "allocation.subjectTaught.subject.name", target = "subjectName")
+    @Mapping(target = "teacherName",  expression = "java(allocation.getSubjectTaught().getTeacher().getUser().getName() + \" \" + allocation.getSubjectTaught().getTeacher().getUser().getLastName())")
+    AllocationResponseDTO toDTO(Allocation allocation);
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/repositories/IAllocationRepository.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/repositories/IAllocationRepository.java
@@ -1,0 +1,7 @@
+package com.web.desenvolvimento.edusphere.repositories;
+
+import com.web.desenvolvimento.edusphere.domain.allocation.Allocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IAllocationRepository extends JpaRepository<Allocation, Long> {
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/services/allocation/AllocationService.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/services/allocation/AllocationService.java
@@ -1,0 +1,48 @@
+package com.web.desenvolvimento.edusphere.services.allocation;
+
+import com.web.desenvolvimento.edusphere.domain.allocation.Allocation;
+import com.web.desenvolvimento.edusphere.domain.allocation.exceptions.SubjectTaughtNotFoundException;
+import com.web.desenvolvimento.edusphere.domain.subjectTaught.SubjectTaught;
+import com.web.desenvolvimento.edusphere.dto.allocation.AllocationRequestDTO;
+import com.web.desenvolvimento.edusphere.dto.allocation.AllocationResponseDTO;
+import com.web.desenvolvimento.edusphere.mappers.IAllocationMapper;
+import com.web.desenvolvimento.edusphere.repositories.IAllocationRepository;
+import com.web.desenvolvimento.edusphere.services.subjectTaught.SubjectTaughtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AllocationService {
+    private final IAllocationRepository allocationRepository;
+    private final IAllocationMapper allocationMapper = IAllocationMapper.INSTANCE;
+    private final SubjectTaughtService subjectTaughtService;
+
+    @Autowired
+    public AllocationService(
+            IAllocationRepository allocationRepository,
+            SubjectTaughtService subjectTaughtService) {
+        this.allocationRepository = allocationRepository;
+        this.subjectTaughtService = subjectTaughtService;
+    }
+
+    public ResponseEntity<AllocationResponseDTO> create(
+            AllocationRequestDTO allocationRequestDTO
+    ){
+        SubjectTaught subjectTaughtInternal = subjectTaughtService.findByIdInternal(
+                allocationRequestDTO.idSubjectTaught()
+        );
+        if (subjectTaughtInternal != null) {
+            Allocation allocationToSave = allocationMapper.toModel(allocationRequestDTO);
+            allocationToSave.setSubjectTaught(subjectTaughtInternal);
+
+            System.out.println("AQUI: " + allocationToSave.getYearAllocation());
+            allocationRepository.save(allocationToSave);
+            AllocationResponseDTO allocationResponseDTO = allocationMapper.toDTO(allocationToSave);
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(allocationResponseDTO);
+        }
+        throw new SubjectTaughtNotFoundException("Código de disciplina lecionada não encontrado");
+    }
+}

--- a/src/main/java/com/web/desenvolvimento/edusphere/services/subjectTaught/SubjectTaughtService.java
+++ b/src/main/java/com/web/desenvolvimento/edusphere/services/subjectTaught/SubjectTaughtService.java
@@ -52,4 +52,10 @@ public class SubjectTaughtService {
         }
         throw new TeacherOrSubjectNotFoundException("Professor ou disciplina não encontrados!");
     }
+
+    @Transactional
+    public SubjectTaught findByIdInternal(Long id) {
+        return subjectTaughtRepository.findById(id).orElseThrow(() -> new RuntimeException(
+                "Código de disciplina lecionada não encontrado"));
+    }
 }


### PR DESCRIPTION
* Manager ou admin podem alocar disciplinas.
* Usa-se não o professor e disciplina diretamente, mas sim o subjectTaught que é a entidade que representa a relação professor x disciplina. Relação essa que é n x n, portanto, ela possuí o id do professor  e disciplina e facilita a inserção e validação da mesma.